### PR TITLE
Update PinStickiedDiscussionsToTop.php

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "the-turk/flarum-stickiest",
+    "name": "lrysia/flarum-stickiest",
     "description": "Stick, super stick or tag stick discussions to the top of the list.",
     "keywords": [
       "flarum",

--- a/src/PinStickiedDiscussionsToTop.php
+++ b/src/PinStickiedDiscussionsToTop.php
@@ -98,9 +98,13 @@ class PinStickiedDiscussionsToTop
             $sticky = clone $query;
             $sticky->where('is_sticky', true);
             $sticky->orders = null;
+            $sticky->limit = null;
+            $sticky->offset = null;
 
             $stickiest = clone $query;
             $stickiest->where('is_stickiest', true);
+            $stickiest->limit = null;
+            $stickiest->offset = null;
 
             $query->union($sticky)->union($stickiest);
 


### PR DESCRIPTION
Fixed a bug: When browsing "All Discussions", if there are sticky/stickiest discussions, the SQL query results(for DiscussionList) sometimes do not meet expectations. It will cause one discussion to be ignored and one or more discussions to be displayed repeatedly.
If the description of the bug above is not clear enough, please watch this video I recorded: (https://youtu.be/vVlAkxUlIjg)