### PR TITLE
Update StickiestModal.js

### DIFF
--- a/js/src/forum/components/StickiestModal.js
+++ b/js/src/forum/components/StickiestModal.js
@@ -20,14 +20,20 @@ export default class StickiestModal extends Modal {
 
     const discussion = this.attrs.discussion;
     const discussionTags = discussion.tags();
-    const stickyTags = Stream(discussion.stickyTags().filter((tag) => discussionTags.indexOf(tag) > -1) || []);
+
 
     this.isSticky = Stream(discussion.isSticky() || false);
     this.isStickiest = Stream(discussion.isStickiest() || false);
     this.isTagSticky = Stream(discussion.isTagSticky() || false);
+    console.log(this.isTagSticky);
+    if (this.isTagSticky == Stream(discussion.isTagSticky())) {
+      const stickyTags = Stream(discussion.stickyTags().filter((tag) => discussionTags.indexOf(tag) > -1) || []);
 
-    if (stickyTags().length > 0) {
-      this.tagSlugs = sortTags(stickyTags()).map((tag) => tag.slug());
+      if (stickyTags().length > 0) {
+        this.tagSlugs = sortTags(stickyTags()).map((tag) => tag.slug());
+      } else {
+        this.tagSlugs = sortTags(discussionTags).map((tag) => tag.slug());
+      }
     } else {
       this.tagSlugs = sortTags(discussionTags).map((tag) => tag.slug());
     }


### PR DESCRIPTION
This change fixes a problem, which causes opening the sticky option of a post that does not come up with the homepage, on clicking "Load more" for example.
I'm pretty unsure if this PR is the intended way of working, but it does work in my case.